### PR TITLE
supporting windows attempt

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -16,6 +16,7 @@ var debug = require('debug')('ProtractorRetry');
 var unique = require('array-unique');
 var childProcess = require('child_process');
 var Q = require('q');
+var spawn = require('cross-spawn');
 var retry;
 
 function afterLaunch(configRetry) {

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -16,7 +16,7 @@ var debug = require('debug')('ProtractorRetry');
 var unique = require('array-unique');
 var childProcess = require('child_process');
 var Q = require('q');
-var spawn = require('cross-spawn');
+var crossSpawn = require('cross-spawn');
 var retry;
 
 function afterLaunch(configRetry) {
@@ -92,6 +92,7 @@ function afterLaunch(configRetry) {
         if (retryCount <= retry) {
             retryLogger(retryCount, fixedSpecList);
             var protExecutionPath = prepareProtractorExecutionPath(argv.$0);
+
             return Q.fcall(spawn(protExecutionPath, protractorCommand));
         }
     }
@@ -143,7 +144,7 @@ function spawn(command, args) {
     debug('Command', command, args);
     return function() {
         return Q.Promise(function() {
-            var child = childProcess.spawn(command, args);
+            var child = childProcess.crossSpawn(command, args);
             child.stdout.pipe(process.stdout);
             child.stderr.pipe(process.stderr);
         });

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -144,7 +144,8 @@ function spawn(command, args) {
     debug('Command', command, args);
     return function() {
         return Q.Promise(function() {
-            var child = childProcess.crossSpawn(command, args);
+            // var child = childProcess.crossSpawn(command, args);
+            var child = child.crossSpawn(command, args);
             child.stdout.pipe(process.stdout);
             child.stderr.pipe(process.stderr);
         });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     }
   ],
   "license": "MIT",
+  "dependencies": {
+    "cross-spawn": "^5.0.0"
+  },
   "devDependencies": {
     "array-unique": "~0.3.2",
     "chai": "3.x",


### PR DESCRIPTION
trying to address https://github.com/yahoo/protractor-retry/issues/13

using this pkg https://www.npmjs.com/package/cross-spawn which seems to solve windows support.

I m a bit blind in that one, as I have no windows machine to test it 🤞 