### PR TITLE
Propagate exitCode

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -32,7 +32,8 @@ function afterLaunch(configRetry) {
     */
     var file = resultsFilePath();
     if (!fs.existsSync(file)) {
-        return;
+      /* Result file is not created, because tests passed, consider as success */
+        return 0;
     }
 
     fs.appendFileSync(file, '</list>');
@@ -93,7 +94,13 @@ function afterLaunch(configRetry) {
             var protExecutionPath = prepareProtractorExecutionPath(argv.$0);
             return Q.fcall(spawn(protExecutionPath, protractorCommand));
         }
+
+        /* There are still outstanding tests and no retry available, consider as failure */
+        return 1;
     }
+
+    /* There are no outstanding tests, consider as success */
+    return 0;
 }
 
 function fixSpecs(specList) {
@@ -141,10 +148,13 @@ function resultsFilePath(retry) {
 function spawn(command, args) {
     debug('Command', command, args);
     return function() {
-        return Q.Promise(function() {
+        return Q.Promise(function(resolve) {
             var child = childProcess.spawn(command, args);
             child.stdout.pipe(process.stdout);
             child.stderr.pipe(process.stderr);
+            child.on('close', (code) => {
+                resolve(code);
+            });
         });
     };
 }


### PR DESCRIPTION
This addresses following issues: 
https://github.com/yahoo/protractor-retry/issues/21
https://github.com/yahoo/protractor-retry/issues/19

Main idea is still make the exitCode valuable to distinguish between failed tests and passing tests. 

With this PR, main process exits with exitCode which is inherited from spawned child doing the retry. And the child which does not spawn new child (because either tests are passing or not enough retries) it returns the exitCode accordingly to indicate failure or success depending if there are still some outstanding specs.

Previously main process was just waiting until child processes finishes without having any meaningful exitCode.

Looking forward to your feedback.

