### PR TITLE
supporting new version of yargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.1.8"></a>
+## 1.1.8 (2018-02-08)
+
+
+### Bug Fixes
+
+* Protractor Config Link in README ([903d0a0](https://github.com/yahoo/Protractor-retry/commit/903d0a0))
+* support of the latest yargs version
+* update README
+
+
 <a name="1.1.7"></a>
 ## 1.1.7 (2017-12-07)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ exports.config = {
 * Checkout this Jasmine (Chrome cap.) Example [protractor.jasmine.conf.js](test/protractor.jasmine.conf.js)
 * Checkout this TestSuite (IE11 cap.) Example with DEBUG activated [protractor.suite.conf.js](test/protractor.suite.conf.js)
 
-Those 3 examples are actually used for the functional tests of this pkg, feel free to take a look at the Travis output to check the flow of the retries.
+Those 3 examples are actually used for the functional tests of this pkg, feel free to take a look at the Travis output to check out the flow of the retries.
 
 ### Known Caveat
 * If you are NOT Running in Parallel mode, the package will retry the whole testsuite if any failure.

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ exports.config = {
 
 ### Examples
 
-* Checkout this Mocha Example [protractor.mocha.conf.js](test/protractor.mocha.conf.js)
-* Checkout this Jasmine Example [protractor.jasmine.conf.js](test/protractor.jasmine.conf.js)
-* Checkout this TestSuite Example with DEBUG activated [protractor.suite.conf.js](test/protractor.suite.conf.js)
+* Checkout this Mocha (Firefox capability) Example [protractor.mocha.conf.js](test/protractor.mocha.conf.js)
+* Checkout this Jasmine (Chrome cap.) Example [protractor.jasmine.conf.js](test/protractor.jasmine.conf.js)
+* Checkout this TestSuite (IE11 cap.) Example with DEBUG activated [protractor.suite.conf.js](test/protractor.suite.conf.js)
 
-Those 3 examples run for the functional tests of this pkg, feel free to take a look to check the flow of the retry.
+Those 3 examples are actually used for the functional tests of this pkg, feel free to take a look at the Travis output to check the flow of the retries.
 
 ### Known Caveat
 * If you are NOT Running in Parallel mode, the package will retry the whole testsuite if any failure.
-* Windows as en environment to launch / use this package is not yet supported.
+* Windows as an environment to launch / use this package is not yet supported.

--- a/README.md
+++ b/README.md
@@ -79,5 +79,8 @@ exports.config = {
 * Checkout this Jasmine Example [protractor.jasmine.conf.js](test/protractor.jasmine.conf.js)
 * Checkout this TestSuite Example with DEBUG activated [protractor.suite.conf.js](test/protractor.suite.conf.js)
 
+Those 3 examples run for the functional tests of this pkg, feel free to take a look to check the flow of the retry.
+
 ### Known Caveat
-If you are NOT Running in Parallel mode, the package will retry the whole testsuite if any failure.
+* If you are NOT Running in Parallel mode, the package will retry the whole testsuite if any failure.
+* Windows as en environment to launch / use this package is not yet supported.

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -75,7 +75,7 @@ function afterLaunch(configRetry) {
         protractorCommand.push('--retry', retryCount);
         protractorCommand.push('--disableChecks');
         /* the remaining command arg */
-        var usedCommandKeys = ['$0', '_', 'test', 'specs', 'retry' , 'suite'];
+        var usedCommandKeys = ['$0', '_', 'test', 'specs', 'retry' , 'suite', 'help', 'version'];
         Object.keys(argv).forEach(function(key) {
             if (usedCommandKeys.indexOf(key) === -1) {
                 if(key === 'params') {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.7",
+  "version": "1.1.8",
   "name": "protractor-retry",
   "description": "module for protractor to automatically re-run failed tests with specific number of attempts",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "q": "^1.4.1",
     "standard-version": "4.2.0",
     "xml2js": "~0.4.17",
-    "yargs": "^4.2.0"
+    "yargs": "^11.0.0"
   },
   "keywords": [
     "protractor",

--- a/test/protractor.local.conf.js
+++ b/test/protractor.local.conf.js
@@ -1,0 +1,27 @@
+/*global browser */
+var retry = require('../lib/retry');
+
+exports.config = {
+    framework: 'jasmine2',
+    specs: ['./jasmine/*.spec.js'],
+    capabilities: {
+        shardTestFiles: true,
+        maxInstances: 4,
+        browserName: 'chrome',
+        Build: 'localrun-'+new Date(),
+        name: __filename
+    },
+    sauceUser: 'YOUR_SAUCE_USER',
+    sauceKey: 'YOUR_SAUCE_KEY',
+    onCleanUp: function (results) {
+        retry.onCleanUp(results);
+    },
+    onPrepare: function () {
+        retry.onPrepare();
+        require('jasmine-expect');
+	browser.ignoreSynchronization = true;
+    },
+    afterLaunch: function() {
+        return retry.afterLaunch(2); // number of retries ( default is 2 )
+    }
+};


### PR DESCRIPTION
attempt to fix https://github.com/yahoo/protractor-retry/issues/20

with newer version of yargs, `version` & `help` are becoming default option of arguments of command line detection using yargs, making the retry failing.

I m just adding those options as preserved option that we want to control and not add  by default.