### PR TITLE
feat(retry):added option to retry on specific files

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -118,9 +118,9 @@ function onPrepare() {
     });
 }
 
-function onCleanUp(results) {
+function onCleanUp(results, files) {
     if (results) {
-        writeToFile();
+        writeToFile(files);
     }
 }
 
@@ -158,9 +158,14 @@ function spawn(command, args) {
     };
 }
 
-function writeToFile() {
+function writeToFile(files) {
     var file = resultsFilePath();
-    var txt = prepareData(browser.currentSpec);
+    var txt = "";
+    if (files && files.length > 0) {
+        txt = prepareData(files);
+    } else {
+        txt = prepareData(browser.currentSpec.specs.toString());
+    }
     if (!fs.existsSync(file)) {
         fs.writeFileSync(file, '<?xml version="1.0" encoding="UTF-8"?>\n<list>\n'+txt);
     } else {
@@ -175,8 +180,8 @@ function retryLogger(attempt, list) {
     console.log('\n');
 }
 
-function prepareData(currentThread) {
-    return '<failedTest>\n<spec>'+currentThread.specs.toString()+'</spec>\n</failedTest>\n';
+function prepareData(files) {
+    return '<failedTest>\n<spec>'+files+'</spec>\n</failedTest>\n';
 }
 
 


### PR DESCRIPTION
This PR gives the option to supply specific files to retry.
This is in needed in order to allow retrying only on failed tests when tests are not running in parallel.