### PR TITLE
Fix typo at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm i -g  protractor-retry
 
 #### Step 1: Require the Package ( Your Protractor Config )
 ```js
-var retry = require('protractor-retry').retry;
+var retry = require('protractor-retry');
 ```
 
 #### Step 2: onPrepare ( Your Protractor Config )


### PR DESCRIPTION
I've followed the instructions at the README and I've noticed that the `retry` import was wrong.