### PR TITLE
Added env variables to override retry protractor command and arguments

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -68,7 +68,11 @@ function afterLaunch(configRetry) {
         });
 
         /* Protractor Command Generator */
-        protractorCommand.push(argv._);
+        if (process.env.PROTRACTOR_RETRY_ARGS) {
+          protractorCommand = protractorCommand.concat(process.env.PROTRACTOR_RETRY_ARGS.split(' '));
+        } else {
+          protractorCommand.push(argv._);
+        }
         var fixedSpecList = fixSpecs(unique(list).join(','));
         protractorCommand.push('--specs', fixedSpecList);
 
@@ -91,7 +95,8 @@ function afterLaunch(configRetry) {
 
         if (retryCount <= retry) {
             retryLogger(retryCount, fixedSpecList);
-            var protExecutionPath = prepareProtractorExecutionPath(argv.$0);
+            var protExecutionPath = process.env.PROTRACTOR_RETRY_COMMAND ?
+              process.env.PROTRACTOR_RETRY_COMMAND : prepareProtractorExecutionPath(argv.$0);
             return Q.fcall(spawn(protExecutionPath, protractorCommand));
         }
 


### PR DESCRIPTION
This change adds support for `PROTRACTOR_RETRY_COMMAND`and `PROTRACTOR_RETRY_ARGS` environment variables.

I was able to get `protractor-retry` working with angular CLI using this approach:

```
PROTRACTOR_CONF='protractor-remote.conf.js';PROTRACTOR_RETRY_COMMAND='./node_modules/.bin/protractor'; export PROTRACTOR_RETRY_ARGS="$PROTRACTOR_CONF  --capabilities.maxInstances=1"; ng e2e  --no-webdriver-     
    update --protractor-config ${PROTRACTOR_CONF}
```