### PR TITLE
command-line parameters for retry attempts fix

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -77,17 +77,24 @@ function afterLaunch(configRetry) {
         protractorCommand.push('--disableChecks');
         /* the remaining command arg */
         var usedCommandKeys = ['$0', '_', 'test', 'specs', 'retry' , 'suite', 'help', 'version'];
-        Object.keys(argv).forEach(function(key) {
-            if (usedCommandKeys.indexOf(key) === -1) {
-                if(key === 'params') {
-                    Object.keys(argv[key]).forEach(function(param) {
-                        protractorCommand.push('--params.'+param, argv[key][param]);
-                    });
-                } else {
-                    protractorCommand.push('--'+key, argv[key]);
+
+        const keyify = (obj, prefix = '--') =>
+            Object.keys(obj).forEach(objectKey => {
+                if (usedCommandKeys.indexOf(objectKey) === -1) {
+                    if(Array.isArray(obj[objectKey]) ) {
+                        Object.keys(obj[objectKey]).forEach(value =>  {
+                            protractorCommand.push(prefix + objectKey, obj[objectKey][value]);
+                        });
+                    }
+                    else if (typeof obj[objectKey] === 'object' && obj[objectKey] !== null) {
+                        keyify(obj[objectKey], prefix + objectKey + '.');
+                    } else {
+                        protractorCommand.push(prefix + objectKey, obj[objectKey]);
+                    }
                 }
-            }
-        });
+            }, []);
+
+        keyify(argv);
 
         if (retryCount <= retry) {
             retryLogger(retryCount, fixedSpecList);


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

There is a fix for this issue [https://github.com/yahoo/protractor-retry/issues/64](Can't handle command-line parameters and using data from protractor.conf.js file for retry attempts instead). Would really appreciate if you take a look into it @davglass . Thanks! 